### PR TITLE
refactor: delete http protocol version

### DIFF
--- a/test/ru/yandex/practicum/kanban/http_api/TestHttpClient.java
+++ b/test/ru/yandex/practicum/kanban/http_api/TestHttpClient.java
@@ -17,7 +17,6 @@ public class TestHttpClient {
 
     public HttpResponse<String> POST(String path, String body) throws Exception {
         HttpRequest request = HttpRequest.newBuilder()
-                .version(HttpClient.Version.HTTP_1_1)
                 .uri(serverURI.resolve(path))
                 .POST(HttpRequest.BodyPublishers.ofString(body))
                 .build();
@@ -27,7 +26,6 @@ public class TestHttpClient {
 
     public HttpResponse<String> GET(String path) throws Exception {
         HttpRequest request = HttpRequest.newBuilder()
-                .version(HttpClient.Version.HTTP_1_1)
                 .uri(serverURI.resolve(path))
                 .GET()
                 .build();
@@ -37,7 +35,6 @@ public class TestHttpClient {
 
     public HttpResponse<String> DELETE(String path) throws Exception {
         HttpRequest request = HttpRequest.newBuilder()
-                .version(HttpClient.Version.HTTP_1_1)
                 .uri(serverURI.resolve(path))
                 .DELETE()
                 .build();

--- a/test/ru/yandex/practicum/kanban/http_api/handlers/SubtasksPathEndpointsTest.java
+++ b/test/ru/yandex/practicum/kanban/http_api/handlers/SubtasksPathEndpointsTest.java
@@ -20,7 +20,7 @@ public class SubtasksPathEndpointsTest extends AbstractPathEndpointsTest {
         String data = SUBTASK_1.toJson();
 
         HttpResponse<String> response = httpClient.POST(PATH, data);
-
+        System.out.println(response);
         assertEquals(CREATED, getStatusFromCode(response.statusCode()));
         assertEquals(1, taskManager.getAllSubtasks().size());
         assertEquals(converter.convert(taskManager.getAllSubtasks().getFirst()), response.body());


### PR DESCRIPTION
for api-test git hub, 
checks how automatically test will gone without Http Protocol version in HttpClient 